### PR TITLE
Removing key signing from the minnieTwitter app

### DIFF
--- a/minnieTwitter/README.md
+++ b/minnieTwitter/README.md
@@ -44,11 +44,6 @@ Alternatively,
     EOF
 ```
 
-### Generate keystores for signing Android apps
-```
-$ cd Amino.Run-Demos/minnieTwitter/
-$ keytool -genkey -v -keystore release.keystore -storepass xxxxxx -alias xxxxxx -keypass xxxxxx -keyalg RSA -keysize 2048 -validity 10000
-```
 ### Building the App
 ```
 $ cd Amino.Run-Demos/

--- a/minnieTwitter/build.gradle
+++ b/minnieTwitter/build.gradle
@@ -16,10 +16,6 @@ plugins {
 apply plugin: 'com.bmuschko.docker-remote-api'
 apply plugin: 'com.android.application'
 
-def keystorePropertiesFile = file("keystore.properties")
-def keystoreProperties = new Properties()
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
-
 android {
     compileSdkVersion = 28
     buildToolsVersion = "28.0.3"
@@ -39,18 +35,8 @@ android {
         targetSdkVersion 28
     }
 
-    signingConfigs {
-        release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-        }
-    }
-
     buildTypes {
         release {
-            signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }

--- a/minnieTwitter/keystore.properties
+++ b/minnieTwitter/keystore.properties
@@ -1,4 +1,0 @@
-keyAlias=xxxxxx
-keyPassword=xxxxxx
-storeFile=release.keystore
-storePassword=xxxxxx


### PR DESCRIPTION
Currently we have a common build.gradle for the chess, hanksTodo and the minnieTwitter app. Due to presence of key signing task in the minnieTwitter build.gradle, ./gradlew build at Amino.Run-Demos level was failing until and unless the user went inside minnieTwitter project, generated the signing at that level. After this we could build the project from the root level. This really seemed like an unwanted task at the user end. Hence removed this key signing task from the build.gradle of minnieTwitter. Moreover no other demo app in the repo uses such practice. Hence, to keep the minnieTwitter app consistent with other apps in the repo this change was done. Also removed the mention for the same from the minniTwitter readme file.